### PR TITLE
fix style warnings

### DIFF
--- a/ffmpeg.rb
+++ b/ffmpeg.rb
@@ -6,9 +6,9 @@ class Ffmpeg < Formula
   head "https://github.com/FFmpeg/FFmpeg.git"
 
   bottle do
-    sha256 "468153bac4b90b445fa5c6adfb70ec3213ebc0f63c7a97a6b2a1649d9c32a786" => :mojave
-    sha256 "152657e2793e9105dacf8badf787f826734b6407741b1e764d91502837c84647" => :high_sierra
-    sha256 "c495601c6e1c14b00d025218a9228706723b3f13f371ec98a7a00eb72066706f" => :sierra
+    sha256 mojave:      "468153bac4b90b445fa5c6adfb70ec3213ebc0f63c7a97a6b2a1649d9c32a786"
+    sha256 high_sierra: "152657e2793e9105dacf8badf787f826734b6407741b1e764d91502837c84647"
+    sha256 sierra:      "c495601c6e1c14b00d025218a9228706723b3f13f371ec98a7a00eb72066706f"
   end
 
   depends_on "nasm" => :build
@@ -24,6 +24,7 @@ class Ffmpeg < Formula
   depends_on "libass"
   depends_on "libbluray"
   depends_on "libsoxr"
+  depends_on "libvidstab"
   depends_on "libvorbis"
   depends_on "libvpx"
   depends_on "opencore-amr"
@@ -40,7 +41,6 @@ class Ffmpeg < Formula
   depends_on "x265"
   depends_on "xvid"
   depends_on "xz"
-  depends_on "libvidstab"
 
   def install
     args = %W[


### PR DESCRIPTION
example
```
Warning: Calling `sha256 "digest" => :tag` in a bottle block is deprecated! Use `brew style --fix` on the formula to update
```
```
$ brew style --fix /usr/local/Homebrew/Library/Taps/pnbv/homebrew-ffmpegvidstab/ffmpeg.rb
...
 /usr/local/Homebrew/Library/Taps/pnbv/homebrew-ffmpegvidstab/ffmpeg.rb:9:5: C: [Corrected] sha256 should use new syntax
    sha256 "468153bac4b90b445fa5c6adfb70ec3213ebc0f63c7a97a6b2a1649d9c32a786" => :mojave
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1 file inspected, 21 offenses detected, 21 offenses corrected
```